### PR TITLE
Backport changes on w.org to GitHub.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: code, content, css, facebook pixel, footer, footer code, footer scripts, f
 Requires at least: 3.6
 Tested up to: 5.4.2
 Requires PHP: 5.2
-Stable tag: 1.4.5
+Stable tag: 1.4.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Thank you
 Syed Balkhi
 
 == Changelog ==
+
+= 1.4.6 =
+* Tested compatibility with WordPress 5.4.2
 
 = 1.4.5 =
 * Tested compatibility with WordPress 5.3.2


### PR DESCRIPTION
WP.org trunk and stable both include minor changes in the readme not present here.