### PR TITLE
Add WP Coding standards to file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "awesomemotive/insert-headers-and-footers",
+    "description": "WordPress plugin allowing you to add extra scripts to your blog.",
+    "type": "wordpress-plugin",
+    "require": {
+        "composer/installers": "^1.9"
+    },
+    "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "~0.6.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.1.0",
+        "wp-coding-standards/wpcs": "~2.3.0"
+    },
+    "license": "GPLv2 or later"
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,480 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "c4ba40b469cbe683df38675d2d3c1fc5",
+    "packages": [
+        {
+            "name": "composer/installers",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "roundcube/plugin-installer": "*",
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.6.* || 2.0.*@dev",
+                "composer/semver": "1.0.* || 2.0.*@dev",
+                "phpunit/phpunit": "^4.8.36",
+                "sebastian/comparator": "^1.2.4",
+                "symfony/process": "^2.3"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "https://composer.github.io/installers/",
+            "keywords": [
+                "Craft",
+                "Dolibarr",
+                "Eliasis",
+                "Hurad",
+                "ImageCMS",
+                "Kanboard",
+                "Lan Management System",
+                "MODX Evo",
+                "MantisBT",
+                "Mautic",
+                "Maya",
+                "OXID",
+                "Plentymarkets",
+                "Porto",
+                "RadPHP",
+                "SMF",
+                "Thelia",
+                "Whmcs",
+                "WolfCMS",
+                "agl",
+                "aimeos",
+                "annotatecms",
+                "attogram",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "cockpit",
+                "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "eZ Platform",
+                "elgg",
+                "expressionengine",
+                "fuelphp",
+                "grav",
+                "installer",
+                "itop",
+                "joomla",
+                "known",
+                "kohana",
+                "laravel",
+                "lavalite",
+                "lithium",
+                "magento",
+                "majima",
+                "mako",
+                "mediawiki",
+                "modulework",
+                "modx",
+                "moodle",
+                "osclass",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "puppet",
+                "pxcms",
+                "reindex",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "sydes",
+                "sylius",
+                "symfony",
+                "typo3",
+                "wordpress",
+                "yawik",
+                "zend",
+                "zikula"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-07T06:57:05+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "^2|^3"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2020-01-29T20:22:20+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "time": "2019-11-04T15:17:54+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/41bef18ba688af638b7310666db28e1ea9158b2f",
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2019-08-28T14:22:28+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2020-10-23T02:01:07+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2020-05-13T23:57:56+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
+}

--- a/ihaf.php
+++ b/ihaf.php
@@ -68,7 +68,7 @@ class InsertHeadersAndFooters {
 		global $pagenow;
 
 		if ( ! get_option( $this->plugin->db_welcome_dismissed_key ) ) {
-			if ( ! ( $pagenow == 'options-general.php' && isset( $_GET['page'] ) && $_GET['page'] == 'insert-headers-and-footers' ) ) {
+			if ( ! ( 'options-general.php' === $pagenow && isset( $_GET['page'] ) && 'insert-headers-and-footers' === $_GET['page'] ) ) {
 				$setting_page = admin_url( 'options-general.php?page=' . $this->plugin->name );
 				// load the notices view
 				include_once( $this->plugin->folder . '/views/dashboard-notices.php' );
@@ -156,7 +156,7 @@ class InsertHeadersAndFooters {
 
 		global $pagenow;
 
-		if ( ! ( $pagenow === 'options-general.php' && isset( $_GET['page'] ) && $_GET['page'] === 'insert-headers-and-footers' ) ) {
+		if ( ! ( 'options-general.php' === $pagenow && isset( $_GET['page'] ) && 'insert-headers-and-footers' === $_GET['page'] ) ) {
 			return;
 		}
 
@@ -224,17 +224,17 @@ class InsertHeadersAndFooters {
 		}
 
 		// provide the opportunity to Ignore IHAF - footer only via filters
-		if ( 'ihaf_insert_footer' == $setting && apply_filters( 'disable_ihaf_footer', false ) ) {
+		if ( 'ihaf_insert_footer' === $setting && apply_filters( 'disable_ihaf_footer', false ) ) {
 			return;
 		}
 
 		// provide the opportunity to Ignore IHAF - header only via filters
-		if ( 'ihaf_insert_header' == $setting && apply_filters( 'disable_ihaf_header', false ) ) {
+		if ( 'ihaf_insert_header' === $setting && apply_filters( 'disable_ihaf_header', false ) ) {
 			return;
 		}
 
 		// provide the opportunity to Ignore IHAF - below opening body only via filters
-		if ( 'ihaf_insert_body' == $setting && apply_filters( 'disable_ihaf_body', false ) ) {
+		if ( 'ihaf_insert_body' === $setting && apply_filters( 'disable_ihaf_body', false ) ) {
 			return;
 		}
 
@@ -243,7 +243,7 @@ class InsertHeadersAndFooters {
 		if ( empty( $meta ) ) {
 			return;
 		}
-		if ( trim( $meta ) == '' ) {
+		if ( trim( $meta ) === '' ) {
 			return;
 		}
 

--- a/ihaf.php
+++ b/ihaf.php
@@ -13,18 +13,18 @@
 
 /*  Copyright 2019 WPBeginner
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License, version 2, as
-    published by the Free Software Foundation.
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License, version 2, as
+	published by the Free Software Foundation.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 /**
@@ -37,54 +37,54 @@ class InsertHeadersAndFooters {
 	public function __construct() {
 
 		// Plugin Details
-        $this->plugin               = new stdClass;
-        $this->plugin->name         = 'insert-headers-and-footers'; // Plugin Folder
-        $this->plugin->displayName  = 'Insert Headers and Footers'; // Plugin Name
-        $this->plugin->version      = '1.4.6';
-        $this->plugin->folder       = plugin_dir_path( __FILE__ );
-        $this->plugin->url          = plugin_dir_url( __FILE__ );
-        $this->plugin->db_welcome_dismissed_key = $this->plugin->name . '_welcome_dismissed_key';
-        $this->body_open_supported	= function_exists( 'wp_body_open' ) && version_compare( get_bloginfo( 'version' ), '5.2' , '>=' );
+		$this->plugin                           = new stdClass;
+		$this->plugin->name                     = 'insert-headers-and-footers'; // Plugin Folder
+		$this->plugin->displayName              = 'Insert Headers and Footers'; // Plugin Name
+		$this->plugin->version                  = '1.4.6';
+		$this->plugin->folder                   = plugin_dir_path( __FILE__ );
+		$this->plugin->url                      = plugin_dir_url( __FILE__ );
+		$this->plugin->db_welcome_dismissed_key = $this->plugin->name . '_welcome_dismissed_key';
+		$this->body_open_supported              = function_exists( 'wp_body_open' ) && version_compare( get_bloginfo( 'version' ), '5.2', '>=' );
 
 		// Hooks
 		add_action( 'admin_init', array( &$this, 'registerSettings' ) );
 		add_action( 'admin_enqueue_scripts', array( &$this, 'initCodeMirror' ) );
-        add_action( 'admin_menu', array( &$this, 'adminPanelsAndMetaBoxes' ) );
-        add_action( 'admin_notices', array( &$this, 'dashboardNotices' ) );
-        add_action( 'wp_ajax_' . $this->plugin->name . '_dismiss_dashboard_notices', array( &$this, 'dismissDashboardNotices' ) );
+		add_action( 'admin_menu', array( &$this, 'adminPanelsAndMetaBoxes' ) );
+		add_action( 'admin_notices', array( &$this, 'dashboardNotices' ) );
+		add_action( 'wp_ajax_' . $this->plugin->name . '_dismiss_dashboard_notices', array( &$this, 'dismissDashboardNotices' ) );
 
-        // Frontend Hooks
-        add_action( 'wp_head', array( &$this, 'frontendHeader' ) );
+		// Frontend Hooks
+		add_action( 'wp_head', array( &$this, 'frontendHeader' ) );
 		add_action( 'wp_footer', array( &$this, 'frontendFooter' ) );
 		if ( $this->body_open_supported ) {
 			add_action( 'wp_body_open', array( &$this, 'frontendBody' ), 1 );
 		}
 	}
 
-    /**
-     * Show relevant notices for the plugin
-     */
-    function dashboardNotices() {
-        global $pagenow;
+	/**
+	 * Show relevant notices for the plugin
+	 */
+	function dashboardNotices() {
+		global $pagenow;
 
-        if ( !get_option( $this->plugin->db_welcome_dismissed_key ) ) {
-        	if ( ! ( $pagenow == 'options-general.php' && isset( $_GET['page'] ) && $_GET['page'] == 'insert-headers-and-footers' ) ) {
-	            $setting_page = admin_url( 'options-general.php?page=' . $this->plugin->name );
-	            // load the notices view
-                include_once( $this->plugin->folder . '/views/dashboard-notices.php' );
-        	}
-        }
-    }
+		if ( ! get_option( $this->plugin->db_welcome_dismissed_key ) ) {
+			if ( ! ( $pagenow == 'options-general.php' && isset( $_GET['page'] ) && $_GET['page'] == 'insert-headers-and-footers' ) ) {
+				$setting_page = admin_url( 'options-general.php?page=' . $this->plugin->name );
+				// load the notices view
+				include_once( $this->plugin->folder . '/views/dashboard-notices.php' );
+			}
+		}
+	}
 
-    /**
-     * Dismiss the welcome notice for the plugin
-     */
-    function dismissDashboardNotices() {
-    	check_ajax_referer( $this->plugin->name . '-nonce', 'nonce' );
-        // user has dismissed the welcome notice
-        update_option( $this->plugin->db_welcome_dismissed_key, 1 );
-        exit;
-    }
+	/**
+	 * Dismiss the welcome notice for the plugin
+	 */
+	function dismissDashboardNotices() {
+		check_ajax_referer( $this->plugin->name . '-nonce', 'nonce' );
+		// user has dismissed the welcome notice
+		update_option( $this->plugin->db_welcome_dismissed_key, 1 );
+		exit;
+	}
 
 	/**
 	* Register Settings
@@ -96,89 +96,89 @@ class InsertHeadersAndFooters {
 	}
 
 	/**
-    * Register the plugin settings panel
-    */
-    function adminPanelsAndMetaBoxes() {
-    	add_submenu_page( 'options-general.php', $this->plugin->displayName, $this->plugin->displayName, 'manage_options', $this->plugin->name, array( &$this, 'adminPanel' ) );
+	* Register the plugin settings panel
+	*/
+	function adminPanelsAndMetaBoxes() {
+		add_submenu_page( 'options-general.php', $this->plugin->displayName, $this->plugin->displayName, 'manage_options', $this->plugin->name, array( &$this, 'adminPanel' ) );
 	}
 
-    /**
-    * Output the Administration Panel
-    * Save POSTed data from the Administration Panel into a WordPress option
-    */
-    function adminPanel() {
+	/**
+	* Output the Administration Panel
+	* Save POSTed data from the Administration Panel into a WordPress option
+	*/
+	function adminPanel() {
 		// only admin user can access this page
-		if ( !current_user_can( 'administrator' ) ) {
+		if ( ! current_user_can( 'administrator' ) ) {
 			echo '<p>' . __( 'Sorry, you are not allowed to access this page.', 'insert-headers-and-footers' ) . '</p>';
 			return;
 		}
 
-    	// Save Settings
-        if ( isset( $_REQUEST['submit'] ) ) {
-        	// Check nonce
-			if ( !isset( $_REQUEST[$this->plugin->name.'_nonce'] ) ) {
-	        	// Missing nonce
-	        	$this->errorMessage = __( 'nonce field is missing. Settings NOT saved.', 'insert-headers-and-footers' );
-        	} elseif ( !wp_verify_nonce( $_REQUEST[$this->plugin->name.'_nonce'], $this->plugin->name ) ) {
-	        	// Invalid nonce
-	        	$this->errorMessage = __( 'Invalid nonce specified. Settings NOT saved.', 'insert-headers-and-footers' );
-        	} else {
-	        	// Save
+		// Save Settings
+		if ( isset( $_REQUEST['submit'] ) ) {
+			// Check nonce
+			if ( ! isset( $_REQUEST[ $this->plugin->name . '_nonce' ] ) ) {
+				// Missing nonce
+				$this->errorMessage = __( 'nonce field is missing. Settings NOT saved.', 'insert-headers-and-footers' );
+			} elseif ( ! wp_verify_nonce( $_REQUEST[ $this->plugin->name . '_nonce' ], $this->plugin->name ) ) {
+				// Invalid nonce
+				$this->errorMessage = __( 'Invalid nonce specified. Settings NOT saved.', 'insert-headers-and-footers' );
+			} else {
+				// Save
 				// $_REQUEST has already been slashed by wp_magic_quotes in wp-settings
 				// so do nothing before saving
-	    		update_option( 'ihaf_insert_header', $_REQUEST['ihaf_insert_header'] );
-	    		update_option( 'ihaf_insert_footer', $_REQUEST['ihaf_insert_footer'] );
+				update_option( 'ihaf_insert_header', $_REQUEST['ihaf_insert_header'] );
+				update_option( 'ihaf_insert_footer', $_REQUEST['ihaf_insert_footer'] );
 				update_option( 'ihaf_insert_body', isset( $_REQUEST['ihaf_insert_body'] ) ? $_REQUEST['ihaf_insert_body'] : '' );
 				update_option( $this->plugin->db_welcome_dismissed_key, 1 );
 				$this->message = __( 'Settings Saved.', 'insert-headers-and-footers' );
 			}
-        }
+		}
 
-        // Get latest settings
-        $this->settings = array(
+		// Get latest settings
+		$this->settings = array(
 			'ihaf_insert_header' => esc_html( wp_unslash( get_option( 'ihaf_insert_header' ) ) ),
 			'ihaf_insert_footer' => esc_html( wp_unslash( get_option( 'ihaf_insert_footer' ) ) ),
-			'ihaf_insert_body' => esc_html( wp_unslash( get_option( 'ihaf_insert_body' ) ) ),
-        );
+			'ihaf_insert_body'   => esc_html( wp_unslash( get_option( 'ihaf_insert_body' ) ) ),
+		);
 
-    	// Load Settings Form
-        include_once( $this->plugin->folder . '/views/settings.php' );
- 	}
+		// Load Settings Form
+		include_once( $this->plugin->folder . '/views/settings.php' );
+	}
 
- 	/**
- 	 * Enqueue and initialize CodeMirror for the form fields.
- 	 */
- 	function initCodeMirror() {
- 		// Make sure that we don't fatal error on WP versions before 4.9.
- 		if ( ! function_exists( 'wp_enqueue_code_editor' ) ) {
- 			return;
- 		}
+	/**
+	 * Enqueue and initialize CodeMirror for the form fields.
+	 */
+	function initCodeMirror() {
+		// Make sure that we don't fatal error on WP versions before 4.9.
+		if ( ! function_exists( 'wp_enqueue_code_editor' ) ) {
+			return;
+		}
 
- 		global $pagenow;
+		global $pagenow;
 
- 		if ( ! ( $pagenow === 'options-general.php' && isset( $_GET['page'] ) && $_GET['page'] === 'insert-headers-and-footers' ) ) {
- 			return;
- 		}
+		if ( ! ( $pagenow === 'options-general.php' && isset( $_GET['page'] ) && $_GET['page'] === 'insert-headers-and-footers' ) ) {
+			return;
+		}
 
- 		// Enqueue code editor and settings for manipulating HTML.
- 		$settings = wp_enqueue_code_editor( array( 'type' => 'text/html' ) );
+		// Enqueue code editor and settings for manipulating HTML.
+		$settings = wp_enqueue_code_editor( array( 'type' => 'text/html' ) );
 
- 		// Bail if user disabled CodeMirror.
- 		if ( false === $settings ) {
- 			return;
- 		}
+		// Bail if user disabled CodeMirror.
+		if ( false === $settings ) {
+			return;
+		}
 
- 		// Custom styles for the form fields.
- 		$styles = ".CodeMirror{ border: 1px solid #ccd0d4; }";
+		// Custom styles for the form fields.
+		$styles = '.CodeMirror{ border: 1px solid #ccd0d4; }';
 
- 		wp_add_inline_style(  'code-editor', $styles );
+		wp_add_inline_style( 'code-editor', $styles );
 
- 		wp_add_inline_script( 'code-editor', sprintf( 'jQuery( function() { wp.codeEditor.initialize( "ihaf_insert_header", %s ); } );', wp_json_encode( $settings ) ) );
- 		wp_add_inline_script( 'code-editor', sprintf( 'jQuery( function() { wp.codeEditor.initialize( "ihaf_insert_body", %s ); } );', wp_json_encode( $settings ) ) );
- 		wp_add_inline_script( 'code-editor', sprintf( 'jQuery( function() { wp.codeEditor.initialize( "ihaf_insert_footer", %s ); } );', wp_json_encode( $settings ) ) );
- 	}
+		wp_add_inline_script( 'code-editor', sprintf( 'jQuery( function() { wp.codeEditor.initialize( "ihaf_insert_header", %s ); } );', wp_json_encode( $settings ) ) );
+		wp_add_inline_script( 'code-editor', sprintf( 'jQuery( function() { wp.codeEditor.initialize( "ihaf_insert_body", %s ); } );', wp_json_encode( $settings ) ) );
+		wp_add_inline_script( 'code-editor', sprintf( 'jQuery( function() { wp.codeEditor.initialize( "ihaf_insert_footer", %s ); } );', wp_json_encode( $settings ) ) );
+	}
 
-    /**
+	/**
 	* Loads plugin textdomain
 	*/
 	function loadLanguageFiles() {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards">
+	<description>Apply WordPress Coding Standards</description>
+
+	<!-- Only scan PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan. -->
+	<arg name="cache"/>
+
+	<!-- Set the memory limit to 256M.
+		 For most standard PHP configurations, this means the memory limit will temporarily be raised.
+		 Ref: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#specifying-phpini-settings
+	-->
+	<ini name="memory_limit" value="256M"/>
+
+	<!-- Check up to 20 files simultaneously. -->
+	<arg name="parallel" value="20"/>
+
+	<!-- Show sniff codes in all reports. -->
+	<arg value="ps"/>
+
+	<file>.</file>
+
+	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
+
+	<!-- Exclude third party code -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -22,6 +22,13 @@
 
 	<file>.</file>
 
+	<!-- Compatibility sniffs -->
+	<rule ref="PHPCompatibilityWP"/>
+
+	<!-- Support older version of WP by supporting PHP 5.2+. -->
+	<config name="testVersion" value="5.2-"/>
+
+	<!-- Style sniffs -->
 	<rule ref="WordPress-Core">
 		<!-- Exclude a few naming rules. -->
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -22,7 +22,12 @@
 
 	<file>.</file>
 
-	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress-Core">
+		<!-- Exclude a few naming rules. -->
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase" />
+	</rule>
 	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
 
 	<!-- Exclude third party code -->

--- a/views/dashboard-notices.php
+++ b/views/dashboard-notices.php
@@ -5,12 +5,13 @@
 ?>
 <div class="notice notice-success is-dismissible <?php echo $this->plugin->name; ?>-notice-welcome">
 	<p>
-		<?php 
-			printf( 
-				/* translators: %s: Name of this plugin */
-				__( 'Thank you for installing %1$s!', 'insert-headers-and-footers' ),
-				$this->plugin->displayName 
-			); ?>
+		<?php
+		printf(
+			/* translators: %s: Name of this plugin */
+			__( 'Thank you for installing %1$s!', 'insert-headers-and-footers' ),
+			$this->plugin->displayName
+		);
+		?>
 		<a href="<?php echo $setting_page; ?>"><?php esc_html_e( 'Click here', 'insert-headers-and-footers' ); ?></a> <?php esc_html_e( 'to configure the plugin.', 'insert-headers-and-footers' ); ?>
 	</p>
 </div>

--- a/views/settings.php
+++ b/views/settings.php
@@ -1,50 +1,50 @@
 <div class="wrap">
-    <h2><?php echo $this->plugin->displayName; ?> &raquo; <?php esc_html_e( 'Settings', 'insert-headers-and-footers' ); ?></h2>
+	<h2><?php echo $this->plugin->displayName; ?> &raquo; <?php esc_html_e( 'Settings', 'insert-headers-and-footers' ); ?></h2>
 
-    <?php
-    if ( isset( $this->message ) ) {
-        ?>
-        <div class="updated fade"><p><?php echo $this->message; ?></p></div>
-        <?php
-    }
-    if ( isset( $this->errorMessage ) ) {
-        ?>
-        <div class="error fade"><p><?php echo $this->errorMessage; ?></p></div>
-        <?php
-    }
-    ?>
+	<?php
+	if ( isset( $this->message ) ) {
+		?>
+		<div class="updated fade"><p><?php echo $this->message; ?></p></div>
+		<?php
+	}
+	if ( isset( $this->errorMessage ) ) {
+		?>
+		<div class="error fade"><p><?php echo $this->errorMessage; ?></p></div>
+		<?php
+	}
+	?>
 
-    <div id="poststuff">
-    	<div id="post-body" class="metabox-holder columns-2">
-    		<!-- Content -->
-    		<div id="post-body-content">
+	<div id="poststuff">
+		<div id="post-body" class="metabox-holder columns-2">
+			<!-- Content -->
+			<div id="post-body-content">
 				<div id="normal-sortables" class="meta-box-sortables ui-sortable">
-	                <div class="postbox">
-	                    <h3 class="hndle"><?php esc_html_e( 'Settings', 'insert-headers-and-footers' ); ?></h3>
+					<div class="postbox">
+						<h3 class="hndle"><?php esc_html_e( 'Settings', 'insert-headers-and-footers' ); ?></h3>
 
-	                    <div class="inside">
-		                    <form action="options-general.php?page=<?php echo $this->plugin->name; ?>" method="post">
-		                    	<p>
-		                    		<label for="ihaf_insert_header"><strong><?php esc_html_e( 'Scripts in Header', 'insert-headers-and-footers' ); ?></strong></label>
-		                    		<textarea name="ihaf_insert_header" id="ihaf_insert_header" class="widefat" rows="8" style="font-family:Courier New;"><?php echo $this->settings['ihaf_insert_header']; ?></textarea>
+						<div class="inside">
+							<form action="options-general.php?page=<?php echo $this->plugin->name; ?>" method="post">
+								<p>
+									<label for="ihaf_insert_header"><strong><?php esc_html_e( 'Scripts in Header', 'insert-headers-and-footers' ); ?></strong></label>
+									<textarea name="ihaf_insert_header" id="ihaf_insert_header" class="widefat" rows="8" style="font-family:Courier New;"><?php echo $this->settings['ihaf_insert_header']; ?></textarea>
 									<?php
-										printf(
-											/* translators: %s: The `<head>` tag */
-											esc_html__( 'These scripts will be printed in the %s section.', 'insert-headers-and-footers' ),
-											'<code>&lt;head&gt;</code>'
-										);
+									printf(
+										/* translators: %s: The `<head>` tag */
+										esc_html__( 'These scripts will be printed in the %s section.', 'insert-headers-and-footers' ),
+										'<code>&lt;head&gt;</code>'
+									);
 									?>
-		                    	</p>
+								</p>
 								<?php if ( $this->body_open_supported ) : ?>
 								<p>
 									<label for="ihaf_insert_body"><strong><?php esc_html_e( 'Scripts in Body', 'insert-headers-and-footers' ); ?></strong></label>
 									<textarea name="ihaf_insert_body" id="ihaf_insert_body" class="widefat" rows="8" style="font-family:Courier New;"><?php echo $this->settings['ihaf_insert_body']; ?></textarea>
 									<?php
-										printf(
-											/* translators: %s: The `<head>` tag */
-											esc_html__( 'These scripts will be printed just below the opening %s tag.', 'insert-headers-and-footers' ),
-											'<code>&lt;body&gt;</code>'
-										);
+									printf(
+										/* translators: %s: The `<head>` tag */
+										esc_html__( 'These scripts will be printed just below the opening %s tag.', 'insert-headers-and-footers' ),
+										'<code>&lt;body&gt;</code>'
+									);
 									?>
 								</p>
 								<?php endif; ?>
@@ -52,31 +52,31 @@
 									<label for="ihaf_insert_footer"><strong><?php esc_html_e( 'Scripts in Footer', 'insert-headers-and-footers' ); ?></strong></label>
 									<textarea name="ihaf_insert_footer" id="ihaf_insert_footer" class="widefat" rows="8" style="font-family:Courier New;"><?php echo $this->settings['ihaf_insert_footer']; ?></textarea>
 									<?php
-										printf(
-											/* translators: %s: The `</body>` tag */
-											esc_html__( 'These scripts will be printed above the closing %s tag.', 'insert-headers-and-footers' ),
-											'<code>&lt;/body&gt;</code>'
-										);
+									printf(
+										/* translators: %s: The `</body>` tag */
+										esc_html__( 'These scripts will be printed above the closing %s tag.', 'insert-headers-and-footers' ),
+										'<code>&lt;/body&gt;</code>'
+									);
 									?>
-		                    	</p>
-		                    	<?php wp_nonce_field( $this->plugin->name, $this->plugin->name . '_nonce' ); ?>
-		                    	<p>
+								</p>
+								<?php wp_nonce_field( $this->plugin->name, $this->plugin->name . '_nonce' ); ?>
+								<p>
 									<input name="submit" type="submit" name="Submit" class="button button-primary" value="<?php esc_attr_e( 'Save', 'insert-headers-and-footers' ); ?>" />
 								</p>
-						    </form>
-	                    </div>
-	                </div>
-	                <!-- /postbox -->
+							</form>
+						</div>
+					</div>
+					<!-- /postbox -->
 				</div>
 				<!-- /normal-sortables -->
-    		</div>
-    		<!-- /post-body-content -->
+			</div>
+			<!-- /post-body-content -->
 
-    		<!-- Sidebar -->
-    		<div id="postbox-container-1" class="postbox-container">
-    			<?php require_once( $this->plugin->folder . '/views/sidebar.php' ); ?>
-    		</div>
-    		<!-- /postbox-container -->
-    	</div>
+			<!-- Sidebar -->
+			<div id="postbox-container-1" class="postbox-container">
+				<?php require_once( $this->plugin->folder . '/views/sidebar.php' ); ?>
+			</div>
+			<!-- /postbox-container -->
+		</div>
 	</div>
 </div>

--- a/views/sidebar.php
+++ b/views/sidebar.php
@@ -6,7 +6,7 @@
 <!-- Improve Your Site -->
 <div class="postbox">
 	<h3 class="hndle">
-		<span><?php esc_html_e('Improve Your Site', 'insert-headers-and-footers'); ?></span>
+		<span><?php esc_html_e( 'Improve Your Site', 'insert-headers-and-footers' ); ?></span>
 	</h3>
 
 	<div class="inside">
@@ -14,33 +14,33 @@
 			<?php
 			printf(
 				/* translators: %s: Link to WPBeginner blog */
-				esc_html__('Want to take your site to the next level? Check out our daily free WordPress tutorials on %s.', 'insert-headers-and-footers'),
+				esc_html__( 'Want to take your site to the next level? Check out our daily free WordPress tutorials on %s.', 'insert-headers-and-footers' ),
 				sprintf(
 					'<a href="http://www.wpbeginner.com/?utm_source=wpadmin&utm_campaign=freeplugins" target="_blank">%s</a>',
-					esc_html__('WPBeginner blog', 'insert-headers-and-footers')
+					esc_html__( 'WPBeginner blog', 'insert-headers-and-footers' )
 				)
 			);
 			?>
 		</p>
 
 		<p>
-			<?php esc_html_e('Some of our popular guides:', 'insert-headers-and-footers'); ?>
+			<?php esc_html_e( 'Some of our popular guides:', 'insert-headers-and-footers' ); ?>
 		</p>
 
 		<ul>
 			<li>
 				<a href="http://www.wpbeginner.com/wordpress-performance-speed/?utm_source=wpadmin&utm_campaign=freeplugins" target="_blank">
-					<?php esc_html_e('Speed Up WordPress', 'insert-headers-and-footers'); ?>
+					<?php esc_html_e( 'Speed Up WordPress', 'insert-headers-and-footers' ); ?>
 				</a>
 			</li>
 			<li>
 				<a href="http://www.wpbeginner.com/wordpress-security/?utm_source=wpadmin&utm_campaign=freeplugins" target="_blank">
-					<?php esc_html_e('Improve WordPress Security', 'insert-headers-and-footers'); ?>
+					<?php esc_html_e( 'Improve WordPress Security', 'insert-headers-and-footers' ); ?>
 				</a>
 			</li>
 			<li>
 				<a href="http://www.wpbeginner.com/wordpress-seo/?utm_source=wpadmin&utm_campaign=freeplugins" target="_blank">
-					<?php esc_html_e('Boost Your WordPress SEO', 'insert-headers-and-footers'); ?>
+					<?php esc_html_e( 'Boost Your WordPress SEO', 'insert-headers-and-footers' ); ?>
 				</a>
 			</li>
 		</ul>
@@ -51,19 +51,19 @@
 <!-- Donate -->
 <div class="postbox">
 	<h3 class="hndle">
-		<span><?php esc_html_e('Our WordPress Plugins', 'insert-headers-and-footers'); ?></span>
+		<span><?php esc_html_e( 'Our WordPress Plugins', 'insert-headers-and-footers' ); ?></span>
 	</h3>
 	<div class="inside">
 		<p>
-			<?php esc_html_e('Like this plugin? Check out our other WordPress plugins:', 'insert-headers-and-footers'); ?>
+			<?php esc_html_e( 'Like this plugin? Check out our other WordPress plugins:', 'insert-headers-and-footers' ); ?>
 		</p>
 		<p>
 			<?php
 			printf(
 				'<a href="%1$s" target="_blank">%2$s</a> - %3$s',
-				esc_url('https://wordpress.org/plugins/wpforms-lite/'),
-				esc_html__('WPForms', 'insert-headers-and-footers'),
-				esc_html__('Drag & Drop WordPress Form Builder', 'insert-headers-and-footers')
+				esc_url( 'https://wordpress.org/plugins/wpforms-lite/' ),
+				esc_html__( 'WPForms', 'insert-headers-and-footers' ),
+				esc_html__( 'Drag & Drop WordPress Form Builder', 'insert-headers-and-footers' )
 			);
 			?>
 		</p>
@@ -71,9 +71,9 @@
 			<?php
 			printf(
 				'<a href="%1$s" target="_blank">%2$s</a> - %3$s',
-				esc_url('https://wordpress.org/plugins/google-analytics-for-wordpress/'),
-				esc_html__('MonsterInsights', 'insert-headers-and-footers'),
-				esc_html__('Google Analytics Made Easy for WordPress', 'insert-headers-and-footers')
+				esc_url( 'https://wordpress.org/plugins/google-analytics-for-wordpress/' ),
+				esc_html__( 'MonsterInsights', 'insert-headers-and-footers' ),
+				esc_html__( 'Google Analytics Made Easy for WordPress', 'insert-headers-and-footers' )
 			);
 			?>
 		</p>
@@ -81,9 +81,9 @@
 			<?php
 			printf(
 				'<a href="%1$s" target="_blank">%2$s</a> - %3$s',
-				esc_url('http://optinmonster.com/'),
-				esc_html__('OptinMonster', 'insert-headers-and-footers'),
-				esc_html__('Best WordPress Lead Generation Plugin', 'insert-headers-and-footers')
+				esc_url( 'http://optinmonster.com/' ),
+				esc_html__( 'OptinMonster', 'insert-headers-and-footers' ),
+				esc_html__( 'Best WordPress Lead Generation Plugin', 'insert-headers-and-footers' )
 			);
 			?>
 		</p>
@@ -91,9 +91,9 @@
 			<?php
 			printf(
 				'<a href="%1$s" target="_blank">%2$s</a> - %3$s',
-				esc_url('https://www.seedprod.com/'),
-				esc_html__('SeedProd', 'insert-headers-and-footers'),
-				esc_html__('Get the best WordPress Coming Soon Page plugin', 'insert-headers-and-footers')
+				esc_url( 'https://www.seedprod.com/' ),
+				esc_html__( 'SeedProd', 'insert-headers-and-footers' ),
+				esc_html__( 'Get the best WordPress Coming Soon Page plugin', 'insert-headers-and-footers' )
 			);
 			?>
 		</p>


### PR DESCRIPTION
* With a few exclusions for backward compatibility uses the WP Config in it's entirety.
* PHP minimum version set to 5.2 to maintain compatibility with older version of WP.
* Runs phpcbf to auto-fix white space changes.
* Manual fixes in 58af39e0f71982883170c46cda7eeb4d0623c76b

Reviewing this with whitespace suppressed will be easier.