### PR TITLE
Fix i18n function/string.

### DIFF
--- a/views/dashboard-notices.php
+++ b/views/dashboard-notices.php
@@ -7,12 +7,15 @@
 	<p>
 		<?php
 		printf(
-			/* translators: %s: Name of this plugin */
-			__( 'Thank you for installing %1$s!', 'insert-headers-and-footers' ),
-			$this->plugin->displayName
+			/* translators: %1$s: Name of this plugin %2$s: Click here */
+			esc_html__( 'Thank you for installing %1$s! %2$s to configure the plugin.', 'insert-headers-and-footers' ),
+			$this->plugin->displayName,
+			sprintf(
+				'<a href="'. $setting_page .'">%s</a>',
+				esc_html__( 'Click here', 'insert-headers-and-footers' )
+			)
 		);
 		?>
-		<a href="<?php echo $setting_page; ?>"><?php esc_html_e( 'Click here', 'insert-headers-and-footers' ); ?></a> <?php esc_html_e( 'to configure the plugin.', 'insert-headers-and-footers' ); ?>
 	</p>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
- Match placeholder on a translator comment and actual string.
- Add one more placeholder for locales that need word order change.
- Combine two strings into one for locales that need spacing between sentences.